### PR TITLE
Workaround for mouse polling rate bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const {setVibrancy: wSetVibrancy, disableVibrancy: wDisableVibrancy} = require("bindings")("vibrancy-wrapper");
 const os = require("os");
 const eBrowserWindow = require("electron").BrowserWindow;
-const {nativeTheme} = require("electron");
+const {nativeTheme, screen} = require("electron");
 const supportedType = ['light', 'dark', 'appearance-based'];
 
 function isWindows10() {
@@ -33,6 +33,62 @@ class vBrowserWindow extends eBrowserWindow {
         const win = new eBrowserWindow(props);
         vBrowserWindow._bindAndReplace(win, vBrowserWindow.setVibrancy);
         if (isWindows10() && props.hasOwnProperty('vibrancy')) win.setVibrancy(props.vibrancy);
+
+        // Replace window moving behavior to fix mouse polling rate bug
+        const pollingRate = 59.997 // TO-DO: Detect the current monitor's refresh rate
+        win.on('will-move', (e) => {
+            e.preventDefault()
+        
+            // Track if the user is moving the window
+            if(win._moveTimeout) clearTimeout(win._moveTimeout);
+            win._moveTimeout = setTimeout(
+              () => {
+                win._isMoving = false
+                clearInterval(win._moveInterval)
+                win._moveInterval = null 
+              }, 1000/60)
+        
+            // Start new behavior if not already
+            if(!win._isMoving) {
+              win._isMoving = true
+              if(win._moveInterval) return false;
+    
+              // Get start positions
+              win._moveLastUpdate = 0
+              win._moveStartBounds = win.getBounds()
+              win._moveStartCursor = screen.getCursorScreenPoint()
+          
+              // Poll at 600hz while moving window
+              win._moveInterval = setInterval(() => {
+                const now = Date.now()
+                if(now >= win._moveLastUpdate + (1000/pollingRate)) {
+                  win._moveLastUpdate = now
+                  const cursor = screen.getCursorScreenPoint()
+          
+                  // Set new position
+                  win.setBounds({
+                    x: win._moveStartBounds.x + (cursor.x - win._moveStartCursor.x),
+                    y: win._moveStartBounds.y + (cursor.y - win._moveStartCursor.y),
+                    width: win._moveStartBounds.width,
+                    height: win._moveStartBounds.height
+                  })
+                }
+              }, 1000/600)
+            }
+
+          })
+        
+          // Replace window resizing behavior to fix mouse polling rate bug
+          win.on('will-resize', (e, newBounds) => {
+            const now = Date.now()
+            if(!win._resizeLastUpdate) win._resizeLastUpdate = 0;
+              if(now >= win._resizeLastUpdate + (1000/pollingRate)) {
+                win._resizeLastUpdate = now
+              } else {
+                e.preventDefault()
+              }
+          })
+
         return win;
     }
 

--- a/test/test.html
+++ b/test/test.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Title</title>
-</head>
-<body style="-webkit-app-region: drag;width:100vw;height:100vh;margin:0;padding:0;">
-</body>
+    <head>
+        <meta charset="UTF-8">
+        <title>Title</title>
+    </head>
+    <body style="width:100vw;height:100vh;margin:0;padding:0;border:1px solid rgba(0,0,0,0.4);background-color: rgba(0,0,0,0.2);box-sizing: border-box;user-select: none;">
+        <div style="-webkit-app-region: drag;width:100%;padding:10px 0;background-color:rgba(0,0,0,0.6);color:white;text-align: center;font-family:system-ui;">Title bar</div>
+    </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,9 @@ function createWindow() {
         height: 600,
         frame: false,
         transparent: true,
-        vibrancy: 'dark'
+        vibrancy: 'dark',
+        minWidth: 200,
+        minHeight: 200
     });
     win.loadURL(`file://${__dirname}/test.html`);
 }


### PR DESCRIPTION
I've implemented a window move/resize throttle to avoid [mouse polling rate lag](https://github.com/Seo-Rii/electron-acrylic-window/issues/6) when using an acrylic window. The move/resize events on the vBrowserWindow are automatically patched on creation.

There are two issues with this workaround at the moment:

1. The refresh rate is hard-coded to ~60hz. I've noticed that some displays will still lag even if you go a little above their refresh rate, so I went with the most common refresh rate. High refresh rate displays (ex. 144hz) will have choppy movement when moving/resizing the window. Proper refresh rate detection is needed to move/resize displays at their full rate.
2. Aero Shake will trigger somewhat randomly. [This appears to be a bug with Electron itself.](https://github.com/electron/electron/issues/20173) 🙁 A workaround to this would be to temporarily disable Aero Shake through the registry, but that's not a great solution.