### PR TITLE
Improved options handling, test app

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,6 +213,7 @@ class vBrowserWindow extends eBrowserWindow {
             async function doFollowUpQueryIfNecessary(cursor) {
                 if (doFollowUpQuery) {
                     const rate = await getRefreshRateAtCursor(cursor);
+                    if(_vibrancyDebug && rate != pollingRate) console.log(`New polling rate: ${rate}`)
                     pollingRate = rate || 30;
                 }
             }

--- a/index.js
+++ b/index.js
@@ -46,10 +46,11 @@ function _setVibrancy(win, vibrancyOp = null) {
             }
         }, 50);
     } else {
-        if (_vibrancyDebug) console.log("Vibrancy Off", vibrancyOp)
+        if (_vibrancyDebug) console.log("Vibrancy Off", vibrancyOp, win._vibrancyOp)
         win._vibrancyActivated = false;
-        if (win._vibrancyOp)
-            win.setBackgroundColor((win._vibrancyOp && win._vibrancyOp.colors ? win._vibrancyOp.colors.blur.substring(0,7) : "#000000"));
+        if (win._vibrancyOp) {
+            win.setBackgroundColor((win._vibrancyOp && win._vibrancyOp.colors && win._vibrancyOp.colors.blur ? "#FE" + win._vibrancyOp.colors.blur.substring(1,7) : "#000000"));
+        }
         setTimeout(() => {
             if (!win._vibrancyActivated) wDisableVibrancy(getHwnd(win));
         }, 10);
@@ -391,12 +392,19 @@ class vBrowserWindow extends eBrowserWindow {
     }
 
     static setVibrancy(op = null) {
-        this._vibrancyOp = opFormatter(op);
-        if (!isWindows10()) super.setVibrancy(this._vibrancyOp);
-        else {
-            if (!op) _setVibrancy(this, null);
-            else _setVibrancy(this, this._vibrancyOp);
+        if(!op) {
+            // If disabling vibrancy, turn off then save
+            _setVibrancy(this, null)
+            this._vibrancyOp = opFormatter(op);
+        } else {
+            this._vibrancyOp = opFormatter(op);
+            if (!isWindows10()) super.setVibrancy(this._vibrancyOp);
+            else {
+                if (!op) _setVibrancy(this, null);
+                else _setVibrancy(this, this._vibrancyOp);
+            }
         }
+        
     }
 
     static _bindAndReplace(object, method) {
@@ -408,11 +416,17 @@ class vBrowserWindow extends eBrowserWindow {
 }
 
 function setVibrancy(win, op = 'appearance-based') {
-    win._vibrancyOp = opFormatter(op);
-    if (!isWindows10()) win.setVibrancy(win._vibrancyOp);
-    else {
-        if (!op) _setVibrancy(this, null);
-        else _setVibrancy(this, win._vibrancyOp);
+    // If disabling vibrancy, turn off then save
+    if(!op) {
+        _setVibrancy(this, null);
+        win._vibrancyOp = opFormatter(op);
+    } else {
+        win._vibrancyOp = opFormatter(op);
+        if (!isWindows10()) win.setVibrancy(win._vibrancyOp);
+        else {
+            if (!op) _setVibrancy(this, null);
+            else _setVibrancy(this, win._vibrancyOp);
+        }
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ function opFormatter(vibrancyProps) {
         theme: false,
         effect: 'acrylic',
         useCustomWindowRefreshMethod: true,
-        maximumRefreshRate: 60,
+        maximumRefreshRate: 1000,
         disableOnBlur: true,
         debug: false
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,9 @@
       }
     },
     "@types/node": {
-      "version": "12.12.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
-      "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w==",
+      "version": "12.12.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.55.tgz",
+      "integrity": "sha512-Vd6xQUVvPCTm7Nx1N7XHcpX6t047ltm7TgcsOr4gFHjeYgwZevo+V7I1lfzHnj5BT5frztZ42+RTG4MwYw63dw==",
       "dev": true
     },
     "abbrev": {
@@ -338,9 +338,9 @@
       }
     },
     "electron": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-9.2.1.tgz",
-      "integrity": "sha512-ZsetaQjXB8+9/EFW1FnfK4ukpkwXCxMEaiKiUZhZ0ZLFlLnFCpe0Bg4vdDf7e4boWGcnlgN1jAJpBw7w0eXuqA==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-10.1.1.tgz",
+      "integrity": "sha512-ZJtZHMr17AvvBosuA6XUmpehwAlGM4/n46Mw9BcyD8tpgdI6IQd0X5OU9meE3X3M8Y6Ja2Kr2udTMgtjvot2hA==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -1269,9 +1269,9 @@
       "dev": true
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "node-gyp rebuild",
     "install": "node-gyp rebuild",
-    "test": "npm run-script build && electron test/test.js"
+    "test": "electron test/test.js"
   },
   "repository": {
     "type": "git",
@@ -40,6 +40,6 @@
     "win32-displayconfig": "^0.1.0"
   },
   "devDependencies": {
-    "electron": "^9.2.1"
+    "electron": "^10.1.1"
   }
 }

--- a/test/src/frameless.js
+++ b/test/src/frameless.js
@@ -2,13 +2,13 @@ const remote = require('electron').remote;
 
 document.onreadystatechange = () => {
     if (document.readyState == "complete") {
+        win = require('electron').remote.getCurrentWindow();
         handleWindowControls();
     }
 };
 
-
+let win;
 function handleWindowControls() {
-    let win = remote.getCurrentWindow();
     document.getElementById('min-button').addEventListener("click", () => {
         win.minimize();
         toggleMaxRestoreButtons();
@@ -37,4 +37,17 @@ function handleWindowControls() {
             document.body.classList.remove('maximized');
         }
     }
+}
+
+window.updateVibrancy = (props = null) => {
+    // Disable vibrancy
+    if(props === null || props === false) {
+        win.setVibrancy();
+        return false;
+    }
+
+    // Enable vibrancy
+    const newProps = Object.assign(win._vibrancyOp || {}, (typeof props === "string" ? { theme: props } : props));
+    win.setVibrancy(props)
+    return true;
 }

--- a/test/test.html
+++ b/test/test.html
@@ -38,6 +38,13 @@
     </form>
 </main>
 <style>
+    html {
+        width: 100%;
+        height: 100%;
+        --window-border: #222;
+        border: 1px solid var(--window-border);
+        box-sizing: border-box;
+    }
     input {
         padding: 10px;
     }
@@ -53,7 +60,9 @@
 </style>
 <script>
     window.updateColor = () => {
-        window.updateVibrancy(document.getElementById("color").value)
+        const color = document.getElementById("color").value
+        window.updateVibrancy(color)
+        window.document.querySelector("html").style.setProperty("--window-border", color.substring(0,7))
     }
     window.toggleAcrylic = () => {
         if(win._vibrancyOp.theme) {

--- a/test/test.html
+++ b/test/test.html
@@ -10,7 +10,7 @@
 <header id="titlebar">
     <div id="drag-region">
         <div id="window-title">
-            <span id="appTitle">Test Application</span>
+            <span id="appTitle">Acrylic Test Application</span>
         </div>
         <div id="window-controls">
             <div class="button" id="min-button">
@@ -28,8 +28,45 @@
         </div>
     </div>
 </header>
-<main>
-    <h1>Test Application!</h1>
+<main style="padding: 20px;">
+    <h1>Acrylic Test Application</h1>
+    <form id="form">
+        <input id="color" value="#12abcd99">
+        <input onclick="window.updateColor()" type="button" value="Update Color" />
+        <input onclick="window.toggleAcrylic()" type="button" value="Toggle Acrylic" />
+        <p>Format: #RRGGBBAA</p>
+    </form>
 </main>
+<style>
+    input {
+        padding: 10px;
+    }
+    h1 {
+        color: white;
+    }
+    p {
+        color: white;
+        opacity: 0.85;
+        font-size: 13px;
+        font-style: italic;
+    }
+</style>
+<script>
+    window.updateColor = () => {
+        window.updateVibrancy(document.getElementById("color").value)
+    }
+    window.toggleAcrylic = () => {
+        if(win._vibrancyOp.theme) {
+            window.updateVibrancy()
+        } else {
+            window.updateVibrancy(document.getElementById("color").value)
+        }
+    }
+    document.getElementById("form").addEventListener("submit", (e) => {
+        e.preventDefault();
+        window.updateColor();
+        return false;
+    })
+</script>
 </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -8,14 +8,15 @@ function createWindow() {
         width: 800,
         height: 600,
         frame: false,
+        transparent: true,
         webPreferences: {
-            nodeIntegration: true
+            nodeIntegration: true,
+            enableRemoteModule: true
         },
         vibrancy: {
-            theme: '#ffffff66',
-            useCustomWindowRefreshMethod: true,
-            maximumRefreshRate: 60,
-            disableOnBlur: false
+            theme: '#12abcd99',
+            disableOnBlur: false,
+            debug: true
         }
     });
     win.loadURL(`file://${__dirname}/test.html`);

--- a/test/test.js
+++ b/test/test.js
@@ -15,10 +15,9 @@ function createWindow() {
             enableRemoteModule: true
         },
         vibrancy: {
-            theme: 'white',
+            theme: '#661237cc',
             effect: 'acrylic',
             useCustomWindowRefreshMethod: true,
-            maximumRefreshRate: 60,
             disableOnBlur: true,
             debug: true
         }

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,8 @@ function createWindow() {
         width: 800,
         height: 600,
         frame: false,
-        transparent: true,
+        backgroundColor: "#00000000",
+        resizable: true,
         webPreferences: {
             nodeIntegration: true,
             enableRemoteModule: true


### PR DESCRIPTION
I've added a number of small improvements and fixes to the library and test script. I recommend reviewing each commit to see what's changed. 
- Updated internal options handling to be a little simpler and better handle errors.
   - `Object.assign()` is now used to set default values instead of manually checking each one (see `opFormatter()` function).
  - Added the internal property `vibrancyOp.colors` when parsing options. This is intended to help pre-calculate colors for events like blur/focus.
- Added an option for debug console output: `{ debug: true }`
- Increased `maximumRefreshRate` to 1000. At 60, it would always cap movement speed by default.
- Fixed `{effect: "acrylic"}` setting the wrong blur type. It was applying the W7-style blur instead of true W10 acrylic.
- Fixed a bug where the incorrect colors may be used when toggling blur on/off.
- Updated Electron to 10.1.1 to fix the 4k maximized screen bug in the test app.
- Updated the test app to be more useful in testing colors. I also added 1px border to max the white line that shows up on non-transparent BrowserWindows at high DPIs.

![test-app](https://user-images.githubusercontent.com/33106561/92541337-b7ca2480-f213-11ea-9165-37f09979571f.jpg)