### PR TITLE
fix: disable custom window refresh method on Windows 11

### DIFF
--- a/src/browserWindow.ts
+++ b/src/browserWindow.ts
@@ -6,7 +6,7 @@ import {
 	Vibrancy,
 	VibrancyConfig,
 } from './vibrancy'
-import { isWindows10, isWindows11 } from './os'
+import { isWindows10OrGreater, isWindows11OrGreater } from './os'
 import win10refresh from './win10refresh'
 import { toggleDebugging } from './debug'
 
@@ -100,7 +100,7 @@ export class BrowserWindow extends electron.BrowserWindow {
 		let config = getConfigFromOptions(options?.vibrancy)
 		let opShowOriginal = options?.show ?? true
 
-		if (isWindows10 && config) {
+		if (isWindows10OrGreater && config) {
 			if (config.colors.base)
 				this.setBackgroundColor(rgbToHex(config.colors.base))
 
@@ -128,14 +128,14 @@ export class BrowserWindow extends electron.BrowserWindow {
 
 			if (this.#winconfig.debug) toggleDebugging(this.#winconfig.debug)
 
-			if (config.useCustomWindowRefreshMethod && !isWindows11)
+			if (config.useCustomWindowRefreshMethod && !isWindows11OrGreater)
 				win10refresh(this, config.maximumRefreshRate || 60)
 
 			if (config.disableOnBlur) {
 				this.#winconfig.opacity = 0
 
 				this.on('blur', () => {
-					if (isWindows10 && this.#winconfig) {
+					if (isWindows10OrGreater && this.#winconfig) {
 						this.#winconfig.targetOpacity = 255
 						if (!this.#winconfig.opacityInterval)
 							this.#winconfig.opacityInterval = setInterval(
@@ -185,7 +185,7 @@ export class BrowserWindow extends electron.BrowserWindow {
 				})
 
 				this.on('focus', () => {
-					if (isWindows10 && this.#winconfig) {
+					if (isWindows10OrGreater && this.#winconfig) {
 						this.#winconfig.targetOpacity =
 							this.#winconfig.vibrnacyConfig.colors.a
 						if (!this.#winconfig.opacityInterval)

--- a/src/browserWindow.ts
+++ b/src/browserWindow.ts
@@ -6,7 +6,7 @@ import {
 	Vibrancy,
 	VibrancyConfig,
 } from './vibrancy'
-import { isWindows10 } from './os'
+import { isWindows10, isWindows11 } from './os'
 import win10refresh from './win10refresh'
 import { toggleDebugging } from './debug'
 
@@ -128,7 +128,7 @@ export class BrowserWindow extends electron.BrowserWindow {
 
 			if (this.#winconfig.debug) toggleDebugging(this.#winconfig.debug)
 
-			if (config.useCustomWindowRefreshMethod)
+			if (config.useCustomWindowRefreshMethod && !isWindows11)
 				win10refresh(this, config.maximumRefreshRate || 60)
 
 			if (config.disableOnBlur) {

--- a/src/os.ts
+++ b/src/os.ts
@@ -3,6 +3,10 @@ import * as os from 'os'
 export const isWindows10 =
 	process.platform === 'win32' && os.release().split('.')[0] === '10'
 
+export const isWindows11 =
+	process.platform === 'win32' &&
+	parseInt(os.release().split('.')[2]) >= 22000
+
 export const isRS4OrGreater =
 	isWindows10 &&
 	!(

--- a/src/os.ts
+++ b/src/os.ts
@@ -11,5 +11,5 @@ export const isRS4OrGreater =
 	isWindows10 &&
 	!(
 		os.release().split('.')[1] === '0' &&
-		parseInt(os.release().split('.')[2]) < 17134
+		parseInt(os.release().split('.')[2], 10) < 17134
 	)

--- a/src/os.ts
+++ b/src/os.ts
@@ -1,14 +1,14 @@
 import * as os from 'os'
 
-export const isWindows10 =
+export const isWindows10OrGreater =
 	process.platform === 'win32' && os.release().split('.')[0] === '10'
 
-export const isWindows11 =
+export const isWindows11OrGreater =
 	process.platform === 'win32' &&
 	parseInt(os.release().split('.')[2]) >= 22000
 
 export const isRS4OrGreater =
-	isWindows10 &&
+	isWindows10OrGreater &&
 	!(
 		os.release().split('.')[1] === '0' &&
 		parseInt(os.release().split('.')[2], 10) < 17134


### PR DESCRIPTION
The `useCustomWindowRefreshMethod` option doesn't appear to be needed on Windows 11, as Microsoft seems to have fixed the issue (finally). This should automatically stop the feature from kicking in, regardless of the options set by the developer.

I'm unable to test this PR completely, as I have no idea how to get the example running. `yarn` can't seem to find my Python installation, and I don't use `yarn` to bother to looking into it. So you should double check this this is working correctly before merging.