### PR TITLE
fix: import bindings only when needed

### DIFF
--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -10,6 +10,7 @@ export interface Bindings {
 	disableVibrancy(hwnd: number): void
 }
 
-const wrapper: Bindings = require('bindings')('vibrancy-wrapper')
-
-export default wrapper
+let _bindings: Bindings | undefined
+export default function bindings(): Bindings {
+	return (_bindings ??= require('bindings')('vibrancy-wrapper'))
+}

--- a/src/vibrancy.ts
+++ b/src/vibrancy.ts
@@ -187,7 +187,7 @@ export function getConfigFromOptions(
 export function _setVibrancy(win: BrowserWindow, config?: VibrancyConfig) {
 	if (config && config.colors) {
 		debug('Vibrancy On', config)
-		bindings.setVibrancy(
+		bindings().setVibrancy(
 			getHwnd(win),
 			config.effect,
 			config.colors.r,
@@ -226,7 +226,7 @@ export function _setVibrancy(win: BrowserWindow, config?: VibrancyConfig) {
 		setTimeout(() => {
 			try {
 				if (!win.__electron_acrylic_window__.vibrancyActivated)
-					bindings.disableVibrancy(getHwnd(win))
+					bindings().disableVibrancy(getHwnd(win))
 			} catch (e) {}
 		}, 10)
 	}


### PR DESCRIPTION
I have only tested on windows, but I *think* it will run just fine on linux and mac too...

Fixes #55