### PR TITLE
Re-enable the ability to use a custom refresh rate on Windows 11

### DIFF
--- a/src/browserWindow.ts
+++ b/src/browserWindow.ts
@@ -6,7 +6,7 @@ import {
 	Vibrancy,
 	VibrancyConfig,
 } from './vibrancy'
-import { isWindows10OrGreater, isWindows11OrGreater } from './os'
+import { isWindows10OrGreater } from './os'
 import win10refresh from './win10refresh'
 import { toggleDebugging } from './debug'
 
@@ -128,7 +128,7 @@ export class BrowserWindow extends electron.BrowserWindow {
 
 			if (this.#winconfig.debug) toggleDebugging(this.#winconfig.debug)
 
-			if (config.useCustomWindowRefreshMethod && !isWindows11OrGreater)
+			if (config.useCustomWindowRefreshMethod)
 				win10refresh(this, config.maximumRefreshRate || 60)
 
 			if (config.disableOnBlur) {

--- a/src/os.ts
+++ b/src/os.ts
@@ -1,7 +1,7 @@
 import * as os from 'os'
 
 export const isWindows10OrGreater =
-	process.platform === 'win32' && os.release().split('.')[0] === '10'
+	process.platform === 'win32' && parseInt(os.release().split('.')[0]) >= 10
 
 export const isRS4OrGreater =
 	isWindows10OrGreater &&

--- a/src/os.ts
+++ b/src/os.ts
@@ -1,7 +1,7 @@
 import * as os from 'os'
 
 export const isWindows10OrGreater =
-	process.platform === 'win32' && parseInt(os.release().split('.')[0]) >= 10
+	process.platform === 'win32' && Number(os.release().split('.')[0]) >= 10
 
 export const isWindows11OrGreater =
 	process.platform === 'win32' &&

--- a/src/os.ts
+++ b/src/os.ts
@@ -3,7 +3,6 @@ import * as os from 'os'
 export const isWindows10OrGreater =
 	process.platform === 'win32' && parseInt(os.release().split('.')[0]) >= 10
 
-
 export const isWindows11OrGreater =
 	process.platform === 'win32' &&
 	parseInt(os.release().split('.')[2]) >= 22000

--- a/src/os.ts
+++ b/src/os.ts
@@ -3,6 +3,12 @@ import * as os from 'os'
 export const isWindows10OrGreater =
 	process.platform === 'win32' && parseInt(os.release().split('.')[0]) >= 10
 
+
+export const isWindows11OrGreater =
+	process.platform === 'win32' &&
+	parseInt(os.release().split('.')[2]) >= 22000
+
+
 export const isRS4OrGreater =
 	isWindows10OrGreater &&
 	!(

--- a/src/os.ts
+++ b/src/os.ts
@@ -8,7 +8,6 @@ export const isWindows11OrGreater =
 	process.platform === 'win32' &&
 	parseInt(os.release().split('.')[2]) >= 22000
 
-
 export const isRS4OrGreater =
 	isWindows10OrGreater &&
 	!(

--- a/src/os.ts
+++ b/src/os.ts
@@ -3,10 +3,6 @@ import * as os from 'os'
 export const isWindows10OrGreater =
 	process.platform === 'win32' && os.release().split('.')[0] === '10'
 
-export const isWindows11OrGreater =
-	process.platform === 'win32' &&
-	parseInt(os.release().split('.')[2]) >= 22000
-
 export const isRS4OrGreater =
 	isWindows10OrGreater &&
 	!(


### PR DESCRIPTION
Note: I couldn't test this locally, so you might want to test this first before accepting the pull request.