### PR TITLE
Added Mac support to allow use in cross-platform environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,56 @@ On Windows 10, `[options]` should be a String or an Object.
 
         If true, log will be printed to console.
 
+## Known Issues
+
+* Known issue on Windows 11 - opening web developer tools will disable the acrylic effect.
+
+## Mac Support
+
+For cross-platform projects for Windows and Mac you need to use the default `electron` BrowserWindow for Mac environments. Here's an example of how to do this in TypeScript:
+
+```typescript
+import os from 'os';
+import {
+  BrowserWindow as MacBrowserWindow,
+  BrowserWindowConstructorOptions,
+} from 'electron';
+import {
+  AcrylicBrowserWindowConstructorOptions,
+  BrowserWindow as WindowsBrowserWindow
+} from 'electron-acrylic-window';
+
+const isWindows = os.platform() === 'win32';
+
+let mainWindow: MacBrowserWindow | WindowsBrowserWindow | null = null;
+
+app.on('ready', function () {
+	const params: BrowserWindowConstructorOptions = {
+    	width: 800,
+    	height: 600,
+    	autoHideMenuBar: true,
+		...
+  	};
+	const macParams: BrowserWindowConstructorOptions = {
+		...params,
+		backgroundColor: '#00000000',
+		vibrancy: 'under-window',
+		visualEffectState: 'active'
+	};
+  	const winParams: AcrylicBrowserWindowConstructorOptions = {
+		...params,
+		vibrancy: {
+		effect: 'acrylic'
+		}
+	};
+	mainWindow = isWindows
+    	? new WindowsBrowserWindow(winParams)
+		: new MacBrowserWindow(macParams);
+});
+
+
+```
+
 ## Demo
 
 To run the demo Electron application, clone this repository, install the dependencies and run the test script:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "electron-acrylic-window",
-	"version": "0.5.11",
+	"version": "0.5.12",
 	"description": "Add vibrancy effect for electron",
 	"keywords": [
 		"node",

--- a/src/win10refresh.ts
+++ b/src/win10refresh.ts
@@ -1,4 +1,3 @@
-import { VerticalRefreshRateContext } from '@seorii/win32-displayconfig'
 import { BrowserWindow } from './browserWindow'
 import * as electron from 'electron'
 import process from 'process'
@@ -69,6 +68,8 @@ export default function win10refresh(
 	win: BrowserWindow,
 	maximumRefreshRate: number
 ) {
+	// Used require to only import dependency for windows only environments (supports compiling on mac without errors)
+	const { VerticalRefreshRateContext } = require('@seorii/win32-displayconfig')
 	const refreshCtx = new VerticalRefreshRateContext()
 
 	function getRefreshRateAtCursor(
@@ -98,7 +99,7 @@ export default function win10refresh(
 		desiredMoveBounds: electron.Rectangle | undefined
 	let boundsPromise: any = Promise.race([
 		getRefreshRateAtCursor(electron.screen.getCursorScreenPoint()).then(
-			(rate) => {
+			(rate: any) => {
 				pollingRate = rate || 30
 				doFollowUpQuery = true
 			}


### PR DESCRIPTION
Added mac support for cross-platform apps. Previous build was erroring on macs due to @seorii/win32-displayconfig  dependency. The change makes the dependency only used if calling win10refresh(). Also, see updated README.md on how to use with Windows and Mac configurations.