### PR TITLE
Fix postinstall error with Node >=18

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  "variables": {
+    "openssl_fips" : "0" 
+  },
   "targets": [
     {
       "target_name": "vibrancy-wrapper",


### PR DESCRIPTION
Fix error on rebuilding packages step

```
gyp: name 'openssl_fips' is not defined while evaluating condition 'openssl_fips != ""' in binding.gyp while trying to load binding.gyp
```

Also [win32-displayconfig](https://github.com/djsweet/win32-displayconfig/pull/6)